### PR TITLE
53 regexp

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -561,6 +561,36 @@ func (sl *StringLiteral) TokenLiteral() string { return sl.Token.Literal }
 // String returns this object as a string.
 func (sl *StringLiteral) String() string { return sl.Token.Literal }
 
+// RegexpLiteral holds a regular-expression.
+type RegexpLiteral struct {
+	// Token is the token
+	Token token.Token
+
+	// Value is the value of the regular expression.
+	Value string
+}
+
+func (rl *RegexpLiteral) expressionNode() {}
+
+// TokenLiteral returns the literal token.
+func (rl *RegexpLiteral) TokenLiteral() string { return rl.Token.Literal }
+
+// String returns this object as a string.
+func (rl *RegexpLiteral) String() string {
+
+	start := "/"
+	val := rl.Token.Literal
+	end := "/"
+
+	if strings.HasPrefix(rl.Token.Literal, "(?i)") {
+		end = "/i"
+		val = strings.TrimPrefix(val, "(?i)")
+	}
+
+	str := start + val + end
+	return str
+}
+
 // BacktickLiteral holds details of a command to be executed
 type BacktickLiteral struct {
 	// Token is the actual token

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 
 	"github.com/skx/monkey/token"
@@ -568,6 +569,9 @@ type RegexpLiteral struct {
 
 	// Value is the value of the regular expression.
 	Value string
+
+	// Flags contains any flags associated with the regexp.
+	Flags string
 }
 
 func (rl *RegexpLiteral) expressionNode() {}
@@ -578,17 +582,7 @@ func (rl *RegexpLiteral) TokenLiteral() string { return rl.Token.Literal }
 // String returns this object as a string.
 func (rl *RegexpLiteral) String() string {
 
-	start := "/"
-	val := rl.Token.Literal
-	end := "/"
-
-	if strings.HasPrefix(rl.Token.Literal, "(?i)") {
-		end = "/i"
-		val = strings.TrimPrefix(val, "(?i)")
-	}
-
-	str := start + val + end
-	return str
+	return (fmt.Sprintf("/%s/%s", rl.Value, rl.Flags))
 }
 
 // BacktickLiteral holds details of a command to be executed

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -142,6 +142,8 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		return &object.Array{Elements: elements}
 	case *ast.StringLiteral:
 		return &object.String{Value: node.Value}
+	case *ast.RegexpLiteral:
+		return &object.Regexp{Value: node.Value}
 	case *ast.BacktickLiteral:
 		return backTickOperation(node.Value)
 	case *ast.IndexExpression:

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -275,8 +275,14 @@ func evalInfixExpression(operator string, left, right object.Object) object.Obje
 		return nativeBoolToBooleanObject(objectToNativeBoolean(left) && objectToNativeBoolean(right))
 	case operator == "||":
 		return nativeBoolToBooleanObject(objectToNativeBoolean(left) || objectToNativeBoolean(right))
+	case operator == "!~":
+		return notMatches(left, right)
+	case operator == "~=":
+		return matches(left, right)
+
 	case operator == "==":
 		return nativeBoolToBooleanObject(left == right)
+
 	case operator == "!=":
 		return nativeBoolToBooleanObject(left != right)
 	case left.Type() == object.BOOLEAN_OBJ && right.Type() == object.BOOLEAN_OBJ:
@@ -288,6 +294,45 @@ func evalInfixExpression(operator string, left, right object.Object) object.Obje
 		return newError("unknown operator: %s %s %s",
 			left.Type(), operator, right.Type())
 	}
+}
+
+func matches(left, right object.Object) object.Object {
+
+	str := left.Inspect()
+
+	// Compile the regular expression.
+	r, err := regexp.Compile(right.Inspect())
+
+	// Ensure it compiled
+	if err != nil {
+		return newError("error compiling regexp '%s': %s", right.Inspect(), err)
+	}
+
+	// Test if it matched
+	if r.MatchString(str) {
+		return TRUE
+	}
+
+	return FALSE
+}
+
+func notMatches(left, right object.Object) object.Object {
+	str := left.Inspect()
+
+	// Compile the regular expression.
+	r, err := regexp.Compile(right.Inspect())
+
+	// Ensure it compiled
+	if err != nil {
+		return newError("error compiling regexp '%s': %s", right.Inspect(), err)
+	}
+
+	// Test if it matched
+	if r.MatchString(str) {
+		return FALSE
+	}
+
+	return TRUE
 }
 
 // boolean operations

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -143,7 +143,7 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 	case *ast.StringLiteral:
 		return &object.String{Value: node.Value}
 	case *ast.RegexpLiteral:
-		return &object.Regexp{Value: node.Value}
+		return &object.Regexp{Value: node.Value, Flags: node.Flags}
 	case *ast.BacktickLiteral:
 		return backTickOperation(node.Value)
 	case *ast.IndexExpression:
@@ -300,8 +300,17 @@ func matches(left, right object.Object) object.Object {
 
 	str := left.Inspect()
 
+	if right.Type() != object.REGEXP_OBJ {
+		return newError("regexp required for regexp-match, given %s", right.Type())
+	}
+
+	val := right.(*object.Regexp).Value
+	if right.(*object.Regexp).Flags != "" {
+		val = "(?" + right.(*object.Regexp).Flags + ")" + val
+	}
+
 	// Compile the regular expression.
-	r, err := regexp.Compile(right.Inspect())
+	r, err := regexp.Compile(val)
 
 	// Ensure it compiled
 	if err != nil {
@@ -319,8 +328,17 @@ func matches(left, right object.Object) object.Object {
 func notMatches(left, right object.Object) object.Object {
 	str := left.Inspect()
 
+	if right.Type() != object.REGEXP_OBJ {
+		return newError("regexp required for regexp-match, given %s", right.Type())
+	}
+
+	val := right.(*object.Regexp).Value
+	if right.(*object.Regexp).Flags != "" {
+		val = "(?" + right.(*object.Regexp).Flags + ")" + val
+	}
+
 	// Compile the regular expression.
-	r, err := regexp.Compile(right.Inspect())
+	r, err := regexp.Compile(val)
 
 	// Ensure it compiled
 	if err != nil {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -1012,6 +1012,8 @@ func objectToNativeBoolean(o object.Object) bool {
 		return obj.Value
 	case *object.String:
 		return obj.Value != ""
+	case *object.Regexp:
+		return obj.Value != ""
 	case *object.Null:
 		return false
 	case *object.Integer:

--- a/evaluator/stdlib_core.go
+++ b/evaluator/stdlib_core.go
@@ -510,6 +510,8 @@ func typeFun(args ...object.Object) object.Object {
 	switch args[0].(type) {
 	case *object.String:
 		return &object.String{Value: "string"}
+	case *object.Regexp:
+		return &object.String{Value: "regexp"}
 	case *object.Boolean:
 		return &object.String{Value: "bool"}
 	case *object.Builtin:

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -42,7 +42,7 @@ let add = fn(x, y){
   x+y;
 };
 let result = add(five, ten);
-!-/ *5;
+!- *5;
 5<10>5;
 
 if(5<10){
@@ -104,7 +104,6 @@ for
 		{token.SEMICOLON, ";"},
 		{token.BANG, "!"},
 		{token.MINUS, "-"},
-		{token.SLASH, "/"},
 		{token.ASTERISK, "*"},
 		{token.INT, "5"},
 		{token.SEMICOLON, ";"},
@@ -489,6 +488,119 @@ func TestIntDotMethod(t *testing.T) {
 		}
 		if tok.Literal != tt.expectedLiteral {
 			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt, tok)
+		}
+	}
+}
+
+// TestRegexp ensures a simple regexp can be parsed.
+func TestRegexp(t *testing.T) {
+	input := `if ( f ~= /steve/i )
+if ( f ~= /steve/m )
+if ( f ~= /steve/mi )
+if ( f ~= /steve/miiiiiiiiiiiiiiiiimmmmmmmmmmmmmiiiii )`
+
+	tests := []struct {
+		expectedType    token.Type
+		expectedLiteral string
+	}{
+		{token.IF, "if"},
+		{token.LPAREN, "("},
+		{token.IDENT, "f"},
+		{token.CONTAINS, "~="},
+		{token.REGEXP, "(?i)steve"},
+		{token.RPAREN, ")"},
+		{token.IF, "if"},
+		{token.LPAREN, "("},
+		{token.IDENT, "f"},
+		{token.CONTAINS, "~="},
+		{token.REGEXP, "(?m)steve"},
+		{token.RPAREN, ")"},
+		{token.IF, "if"},
+		{token.LPAREN, "("},
+		{token.IDENT, "f"},
+		{token.CONTAINS, "~="},
+		{token.REGEXP, "(?mi)steve"},
+		{token.RPAREN, ")"},
+		{token.IF, "if"},
+		{token.LPAREN, "("},
+		{token.IDENT, "f"},
+		{token.CONTAINS, "~="},
+		{token.REGEXP, "(?mi)steve"},
+		{token.RPAREN, ")"},
+		{token.EOF, ""},
+	}
+	l := New(input)
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}
+
+// TestIllegalRegexp is designed to look for an unterminated/illegal regexp
+func TestIllegalRegexp(t *testing.T) {
+	input := `if ( f ~= /steve )`
+
+	tests := []struct {
+		expectedType    token.Type
+		expectedLiteral string
+	}{
+		{token.IF, "if"},
+		{token.LPAREN, "("},
+		{token.IDENT, "f"},
+		{token.CONTAINS, "~="},
+		{token.REGEXP, "unterminated regular expression"},
+		{token.EOF, ""},
+	}
+	l := New(input)
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}
+
+// TestDiv is designed to test that a division is recognized; that it is
+// not confused with a regular-expression.
+func TestDiv(t *testing.T) {
+	input := `a = b / c;
+a = 3/4;
+`
+
+	tests := []struct {
+		expectedType    token.Type
+		expectedLiteral string
+	}{
+		{token.IDENT, "a"},
+		{token.ASSIGN, "="},
+		{token.IDENT, "b"},
+		{token.SLASH, "/"},
+		{token.IDENT, "c"},
+		{token.SEMICOLON, ";"},
+		{token.IDENT, "a"},
+		{token.ASSIGN, "="},
+		{token.INT, "3"},
+		{token.SLASH, "/"},
+		{token.INT, "4"},
+		{token.SEMICOLON, ";"},
+		{token.EOF, ""},
+	}
+	l := New(input)
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
 		}
 	}
 }

--- a/object/object.go
+++ b/object/object.go
@@ -18,6 +18,7 @@ const (
 	ARRAY_OBJ        = "ARRAY"
 	HASH_OBJ         = "HASH"
 	FILE_OBJ         = "FILE"
+	REGEXP_OBJ       = "REGEXP"
 )
 
 // Object is the interface that all of our various object-types must implmenet.

--- a/object/object_regexp.go
+++ b/object/object_regexp.go
@@ -2,7 +2,7 @@
 
 package object
 
-// Regexp wraps regular-expressions and implements Object and Hashable interfaces.
+// Regexp wraps regular-expressions and implements the Object interface.
 type Regexp struct {
 	// Value holds the string value this object wraps.
 	Value string

--- a/object/object_regexp.go
+++ b/object/object_regexp.go
@@ -6,6 +6,9 @@ package object
 type Regexp struct {
 	// Value holds the string value this object wraps.
 	Value string
+
+	// Flags holds the flags for the object
+	Flags string
 }
 
 // Type returns the type of this object.

--- a/object/object_regexp.go
+++ b/object/object_regexp.go
@@ -1,0 +1,25 @@
+// The implementation of our regular-expression object.
+
+package object
+
+// Regexp wraps regular-expressions and implements Object and Hashable interfaces.
+type Regexp struct {
+	// Value holds the string value this object wraps.
+	Value string
+}
+
+// Type returns the type of this object.
+func (s *Regexp) Type() Type {
+	return REGEXP_OBJ
+}
+
+// Inspect returns a string-representation of the given object.
+func (r *Regexp) Inspect() string {
+	return r.Value
+}
+
+// InvokeMethod invokes a method against the object.
+// (Built-in methods only.)
+func (s *Regexp) InvokeMethod(method string, env Environment, args ...Object) Object {
+	return nil
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -23,28 +23,32 @@ type (
 const (
 	_ int = iota
 	LOWEST
-	COND        // OR or AND
-	ASSIGN      // =
-	EQUALS      // == or !=
-	LESSGREATER // > or <
-	SUM         // + or -
-	PRODUCT     // * or /
-	POWER       // **
-	MOD         // %
-	PREFIX      // -X or !X
-	CALL        // myFunction(X)
-	INDEX       // array[index], map[key]
+	COND         // OR or AND
+	ASSIGN       // =
+	EQUALS       // == or !=
+	REGEXP_MATCH // !~ ~=
+	LESSGREATER  // > or <
+	SUM          // + or -
+	PRODUCT      // * or /
+	POWER        // **
+	MOD          // %
+	PREFIX       // -X or !X
+	CALL         // myFunction(X)
+	INDEX        // array[index], map[key]
 )
 
 // each token precedence
 var precedences = map[token.Type]int{
-	token.ASSIGN:          ASSIGN,
-	token.EQ:              EQUALS,
-	token.NOT_EQ:          EQUALS,
-	token.LT:              LESSGREATER,
-	token.LT_EQUALS:       LESSGREATER,
-	token.GT:              LESSGREATER,
-	token.GT_EQUALS:       LESSGREATER,
+	token.ASSIGN:       ASSIGN,
+	token.EQ:           EQUALS,
+	token.NOT_EQ:       EQUALS,
+	token.LT:           LESSGREATER,
+	token.LT_EQUALS:    LESSGREATER,
+	token.GT:           LESSGREATER,
+	token.GT_EQUALS:    LESSGREATER,
+	token.CONTAINS:     REGEXP_MATCH,
+	token.NOT_CONTAINS: REGEXP_MATCH,
+
 	token.PLUS:            SUM,
 	token.PLUS_EQUALS:     SUM,
 	token.MINUS:           SUM,
@@ -102,6 +106,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.prefixParseFns = make(map[token.Type]prefixParseFn)
 	p.registerPrefix(token.IDENT, p.parseIdentifier)
 	p.registerPrefix(token.INT, p.parseIntegerLiteral)
+	p.registerPrefix(token.REGEXP, p.parseRegexpLiteral)
 	p.registerPrefix(token.FLOAT, p.parseFloatLiteral)
 	p.registerPrefix(token.TRUE, p.parseBoolean)
 	p.registerPrefix(token.FALSE, p.parseBoolean)
@@ -141,6 +146,8 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.MINUS_EQUALS, p.parseAssignExpression)
 	p.registerInfix(token.ASTERISK_EQUALS, p.parseAssignExpression)
 	p.registerInfix(token.SLASH_EQUALS, p.parseAssignExpression)
+	p.registerInfix(token.CONTAINS, p.parseInfixExpression)
+	p.registerInfix(token.NOT_CONTAINS, p.parseInfixExpression)
 
 	p.postfixParseFns = make(map[token.Type]postfixParseFn)
 	p.registerPostfix(token.PLUS_PLUS, p.parsePostfixExpression)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -116,6 +116,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.BACKTICK, p.parseBacktickLiteral)
 	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
 	p.registerPrefix(token.LBRACE, p.parseHashLiteral)
+	p.registerPrefix(token.REGEXP, p.parseRegexpLiteral)
 
 	p.infixParseFns = make(map[token.Type]infixParseFn)
 	p.registerInfix(token.ASSIGN, p.parseAssignExpression)
@@ -517,6 +518,11 @@ func (p *Parser) parseFunctionParameters() (map[string]ast.Expression, []*ast.Id
 // parseStringLiteral parses a string-literal.
 func (p *Parser) parseStringLiteral() ast.Expression {
 	return &ast.StringLiteral{Token: p.curToken, Value: p.curToken.Literal}
+}
+
+// parseRegexpLiteral parses a regular-expression.
+func (p *Parser) parseRegexpLiteral() ast.Expression {
+	return &ast.RegexpLiteral{Token: p.curToken, Value: p.curToken.Literal}
 }
 
 // parseBacktickLiteral parses a backtick-expression.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -529,7 +529,28 @@ func (p *Parser) parseStringLiteral() ast.Expression {
 
 // parseRegexpLiteral parses a regular-expression.
 func (p *Parser) parseRegexpLiteral() ast.Expression {
-	return &ast.RegexpLiteral{Token: p.curToken, Value: p.curToken.Literal}
+
+	flags := ""
+
+	val := p.curToken.Literal
+	if strings.HasPrefix(val, "(?") {
+		val = strings.TrimPrefix(val, "(?")
+
+		i := 0
+		for i < len(val) {
+
+			if val[i] == ')' {
+
+				val = val[i+1:]
+				break
+			} else {
+				flags += string(val[i])
+			}
+
+			i++
+		}
+	}
+	return &ast.RegexpLiteral{Token: p.curToken, Value: val, Flags: flags}
 }
 
 // parseBacktickLiteral parses a backtick-expression.

--- a/token/token.go
+++ b/token/token.go
@@ -60,6 +60,9 @@ const (
 	RBRACKET        = "]"
 	COLON           = ":"
 	PERIOD          = "."
+	CONTAINS        = "~="
+	NOT_CONTAINS    = "!~"
+	ILLEGAL         = "ILLEGAL"
 )
 
 // reversed keywords

--- a/token/token.go
+++ b/token/token.go
@@ -55,6 +55,7 @@ const (
 	EQ              = "=="
 	NOT_EQ          = "!="
 	STRING          = "STRING"
+	REGEXP          = "REGEXP"
 	LBRACKET        = "["
 	RBRACKET        = "]"
 	COLON           = ":"


### PR DESCRIPTION
This pull request will close #53, by implementing support for regular expressions as objects.

Currently the following program works:

```
frodo ~/Repos/github.com/skx/monkey $ cat reg.mon
x = /steve/i;

puts( x, " is type:" , type(x), "\n" );
```

It produces:

```
frodo ~/Repos/github.com/skx/monkey $ go build . ; ./monkey reg.mon 
(?i)steve is type:regexp
```

Note here the flag `/i` has been converted to the version go prefers, the `(?i)` prefix.

Outstanding task is mostly to implement `!~` and `=~` operators.