### PR TITLE
Added 'printf' and 'sprintf' primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ The interpreter in _this_ repository has been significantly extended from the st
 * Added support for [ternary expressions](#261-ternary-expressions).
 * Added support for creating arrays of consecutive integers via the range operator (`1..10`).
 * Added the ability to iterate over the contents of arrays, hashes, and strings via the `foreach` statement.
-
+* Added `printf` and `sprintf` primitives, which work as you would expect.
+  * `printf( "%d %s", 3, "Steve" );`
 
 
 ## 1. Installation
@@ -267,9 +268,13 @@ The core primitives are:
 * `push`
   * push an elements into the array.
 * `puts`
-  * print literal value of objects.
+  * Write literal value of objects to STDOUT.
+* `printf`
+  * Write values to STDOUT, via a format-string.
 * `set`
   * insert key value pair into the map.
+* `sprintf`
+  * Create strings, via a format-string.
 * `string`
   * convert the given item to a string.
 * `type`

--- a/evaluator/stdlib_core.go
+++ b/evaluator/stdlib_core.go
@@ -340,6 +340,55 @@ func putsFun(args ...object.Object) object.Object {
 	return NULL
 }
 
+// printfFun is the implementation of our `printf` function.
+func printfFun(args ...object.Object) object.Object {
+
+	// Convert to the formatted version, via our `sprintf`
+	// function.
+	out := sprintfFun(args...)
+
+	// If that returned a string then we can print it
+	if out.Type() == object.STRING_OBJ {
+		fmt.Print(out.(*object.String).Value)
+
+	}
+
+	return NULL
+}
+
+// sprintfFun is the implementation of our `sprintf` function.
+func sprintfFun(args ...object.Object) object.Object {
+
+	// We expect 1+ arguments
+	if len(args) < 1 {
+		return &object.Null{}
+	}
+
+	// Type-check
+	if args[0].Type() != object.STRING_OBJ {
+		return &object.Null{}
+	}
+
+	// Get the format-string.
+	fs := args[0].(*object.String).Value
+
+	// Convert the arguments to something go's sprintf
+	// code will understand.
+	argLen := len(args)
+	fmtArgs := make([]interface{}, argLen-1)
+
+	// Here we convert and assign.
+	for i, v := range args[1:] {
+		fmtArgs[i] = v.ToInterface()
+	}
+
+	// Call the helper
+	out := fmt.Sprintf(fs, fmtArgs...)
+
+	// And now return the value.
+	return &object.String{Value: out}
+}
+
 // Get file info.
 func statFun(args ...object.Object) object.Object {
 
@@ -603,9 +652,17 @@ func init() {
 		func(env *object.Environment, args ...object.Object) object.Object {
 			return (putsFun(args...))
 		})
+	RegisterBuiltin("printf",
+		func(env *object.Environment, args ...object.Object) object.Object {
+			return (printfFun(args...))
+		})
 	RegisterBuiltin("set",
 		func(env *object.Environment, args ...object.Object) object.Object {
 			return (setFun(args...))
+		})
+	RegisterBuiltin("sprintf",
+		func(env *object.Environment, args ...object.Object) object.Object {
+			return (sprintfFun(args...))
 		})
 	RegisterBuiltin("stat",
 		func(env *object.Environment, args ...object.Object) object.Object {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -257,7 +257,7 @@ func (l *Lexer) NextToken() token.Token {
 	default:
 
 		if isDigit(l.ch) {
-			tok := l.readDecimal()
+			tok = l.readDecimal()
 			l.prevToken = tok
 			return tok
 

--- a/object/object.go
+++ b/object/object.go
@@ -33,6 +33,11 @@ type Object interface {
 	// InvokeMethod invokes a method against the object.
 	// (Built-in methods only.)
 	InvokeMethod(method string, env Environment, args ...Object) Object
+
+	// ToInterface converts the given object to a "native" golang value,
+	// which is required to ensure that we can use the object in our
+	// `sprintf` or `printf` primitives.
+	ToInterface() interface{}
 }
 
 // Hashable type can be hashed

--- a/object/object_array.go
+++ b/object/object_array.go
@@ -80,3 +80,11 @@ func (ao *Array) Next() (Object, Object, bool) {
 
 	return nil, &Integer{Value: 0}, false
 }
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (ao *Array) ToInterface() interface{} {
+	return "ARRAY"
+}

--- a/object/object_bool.go
+++ b/object/object_bool.go
@@ -58,3 +58,11 @@ func (b *Boolean) InvokeMethod(method string, env Environment, args ...Object) O
 	}
 	return nil
 }
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (b *Boolean) ToInterface() interface{} {
+	return b.Value
+}

--- a/object/object_builtin.go
+++ b/object/object_builtin.go
@@ -33,3 +33,11 @@ func (b *Builtin) InvokeMethod(method string, env Environment, args ...Object) O
 	}
 	return nil
 }
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (b *Builtin) ToInterface() interface{} {
+	return "<BUILTIN>"
+}

--- a/object/object_error.go
+++ b/object/object_error.go
@@ -27,3 +27,11 @@ func (e *Error) InvokeMethod(method string, env Environment, args ...Object) Obj
 	//
 	return nil
 }
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (e *Error) ToInterface() interface{} {
+	return "<ERROR>"
+}

--- a/object/object_file.go
+++ b/object/object_file.go
@@ -198,3 +198,11 @@ func (f *File) InvokeMethod(method string, env Environment, args ...Object) Obje
 	}
 	return nil
 }
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (f *File) ToInterface() interface{} {
+	return "<FILE>"
+}

--- a/object/object_float.go
+++ b/object/object_float.go
@@ -55,3 +55,11 @@ func (f *Float) InvokeMethod(method string, env Environment, args ...Object) Obj
 	}
 	return nil
 }
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (f *Float) ToInterface() interface{} {
+	return f.Value
+}

--- a/object/object_function.go
+++ b/object/object_function.go
@@ -62,3 +62,11 @@ func (f *Function) InvokeMethod(method string, env Environment, args ...Object) 
 	}
 	return nil
 }
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (f *Function) ToInterface() interface{} {
+	return "<FUNCTION>"
+}

--- a/object/object_hash.go
+++ b/object/object_hash.go
@@ -115,3 +115,11 @@ func (h *Hash) Next() (Object, Object, bool) {
 
 	return nil, &Integer{Value: 0}, false
 }
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (h *Hash) ToInterface() interface{} {
+	return "<HASH>"
+}

--- a/object/object_int.go
+++ b/object/object_int.go
@@ -55,3 +55,11 @@ func (i *Integer) InvokeMethod(method string, env Environment, args ...Object) O
 	}
 	return nil
 }
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (i *Integer) ToInterface() interface{} {
+	return i.Value
+}

--- a/object/object_null.go
+++ b/object/object_null.go
@@ -18,3 +18,11 @@ func (n *Null) Inspect() string {
 func (n *Null) InvokeMethod(method string, env Environment, args ...Object) Object {
 	return nil
 }
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (n *Null) ToInterface() interface{} {
+	return "<NULL>"
+}

--- a/object/object_regexp.go
+++ b/object/object_regexp.go
@@ -26,3 +26,11 @@ func (r *Regexp) Inspect() string {
 func (r *Regexp) InvokeMethod(method string, env Environment, args ...Object) Object {
 	return nil
 }
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (r *Regexp) ToInterface() interface{} {
+	return "<REGEXP>"
+}

--- a/object/object_return.go
+++ b/object/object_return.go
@@ -27,3 +27,11 @@ func (rv *ReturnValue) InvokeMethod(method string, env Environment, args ...Obje
 	//
 	return nil
 }
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (rv *ReturnValue) ToInterface() interface{} {
+	return "<RETURN_VALUE>"
+}

--- a/object/object_string.go
+++ b/object/object_string.go
@@ -106,3 +106,11 @@ func (s *String) Next() (Object, Object, bool) {
 
 	return nil, &Integer{Value: 0}, false
 }
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (s *String) ToInterface() interface{} {
+	return s.Value
+}


### PR DESCRIPTION
This pull-request implements `printf` and `sprintf`, to allow formatting output in a way that users would expect:

      printf( "Hello, my name is %s, you are %d\n", "Steve", 43 );
