### PR TITLE
Rather than treating the shebang as special make '#' a comment

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -69,13 +69,8 @@ func (l *Lexer) NextToken() token.Token {
 	l.skipWhitespace()
 
 	// skip single-line comments
-	if l.ch == rune('/') && l.peekChar() == rune('/') {
-		l.skipComment()
-		return (l.NextToken())
-	}
-
-	// skip shebang
-	if l.ch == rune('#') && l.peekChar() == rune('!') && l.position == 0 {
+	if l.ch == rune('#') ||
+		(l.ch == rune('/') && l.peekChar() == rune('/')) {
 		l.skipComment()
 		return (l.NextToken())
 	}

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -203,7 +203,8 @@ func TestUnicodeLexer(t *testing.T) {
 func TestSimpleComment(t *testing.T) {
 	input := `=+// This is a comment
 // This is still a comment
-let a = 1;
+# I like comments
+let a = 1; # This is a comment too.
 // This is a final
 // comment on two-lines`
 


### PR DESCRIPTION
This is more consistent.