### PR TITLE
77 ci

### DIFF
--- a/.github/run-tests.sh
+++ b/.github/run-tests.sh
@@ -23,7 +23,7 @@ echo "Launching linter .."
 if [ -s lint.out ]; then
     echo "Linter errors: "
     cat lint.out
-    exit 0
+    exit 1
 else
     rm lint.out
 fi

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -758,7 +758,7 @@ func evalSwitchStatement(se *ast.SwitchExpression, env *object.Environment) obje
 				(obj.Inspect() == out.Inspect()) {
 
 				// Evaluate the block and return the value
-				out := evalBlockStatement(opt.Block, env)
+				out = evalBlockStatement(opt.Block, env)
 				return out
 			}
 

--- a/object/environment.go
+++ b/object/environment.go
@@ -120,10 +120,10 @@ func (e *Environment) Set(name string, val Object) Object {
 		// ok we're not permitted, we must store in the parent
 		if e.outer != nil {
 			return e.outer.Set(name, val)
-		} else {
-			fmt.Printf("scoping weirdness; please report a bug\n")
-			os.Exit(5)
 		}
+
+		fmt.Printf("scoping weirdness; please report a bug\n")
+		os.Exit(5)
 	}
 	e.store[name] = val
 	return val


### PR DESCRIPTION
Previously when the linter found errors it would terminate with `exit 0`, which caused the github-actions to regard this as a "success".

This pull-request ensures we report an error, and then updates our code to resolve two issues which the linter was identifying.

This closes #77.