### PR TITLE
Added "EvalContext"

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -30,13 +30,19 @@ var builtins = map[string]*object.Builtin{}
 
 // Eval is our core function for evaluating nodes.
 func Eval(node ast.Node, env *object.Environment) object.Object {
+	return EvalContext(context.Background(), node, env)
+}
+
+// EvalContext is our core function for evaluating nodes.
+// The context.Context provided can be used to cancel a running script instance.
+func EvalContext(ctx context.Context, node ast.Node, env *object.Environment) object.Object {
 
 	//
 	// We test our context at every iteration of our main-loop.
 	//
 	select {
-	case <-CTX.Done():
-		return &object.Error{Message: CTX.Err().Error()}
+	case <-ctx.Done():
+		return &object.Error{Message: ctx.Err().Error()}
 	default:
 		// nop
 	}


### PR DESCRIPTION
Having a global Context can be useful, but causes some issues.

- Can only be used with a single Monkey script instance (Canceling one would cancel the others or if the base CTX wasn't replaced properly)
- Could allow for a panic if a caller sets CTX to nil before execution (example could be bad cleanup/replacement of previous runs)

Purposed a new function "EvalContext", inline with Go compatibility guidelines such as "exec.Command" [here](https://pkg.go.dev/os/exec#CommandContext) that would allow for non-breaking updates. This new function would perform the work "Eval" previously did and the "Eval" function would call this function with the background context to keep with previous execution behavior.