### PR TITLE
Null

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -300,6 +300,20 @@ func (pe *PostfixExpression) String() string {
 	return out.String()
 }
 
+// NullLiteral represents a literal null
+type NullLiteral struct {
+	// Token holds the actual token
+	Token token.Token
+}
+
+func (n *NullLiteral) expressionNode() {}
+
+// TokenLiteral returns the literal token.
+func (n *NullLiteral) TokenLiteral() string { return n.Token.Literal }
+
+// String returns this object as a string.
+func (n *NullLiteral) String() string { return n.Token.Literal }
+
 // Boolean holds a boolean type
 type Boolean struct {
 	// Token holds the actual token

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -62,6 +62,8 @@ func EvalContext(ctx context.Context, node ast.Node, env *object.Environment) ob
 		return &object.Float{Value: node.Value}
 	case *ast.Boolean:
 		return nativeBoolToBooleanObject(node.Value)
+	case *ast.NullLiteral:
+		return NULL
 	case *ast.PrefixExpression:
 		right := Eval(node.Right, env)
 		if isError(right) {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -6,6 +6,30 @@ import (
 	"github.com/skx/monkey/token"
 )
 
+func TestNull(t *testing.T) {
+	input := "a = null;"
+	tests := []struct {
+		expectedType    token.Type
+		expectedLiteral string
+	}{
+		{token.IDENT, "a"},
+		{token.ASSIGN, "="},
+		{token.NULL, "null"},
+		{token.SEMICOLON, ";"},
+		{token.EOF, ""},
+	}
+	l := New(input)
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}
+
 func TestNextToken1(t *testing.T) {
 	input := "%=+(){},;?|| &&`/bin/ls`++--***=.."
 
@@ -200,6 +224,28 @@ func TestUnicodeLexer(t *testing.T) {
 	}
 }
 
+func TestString(t *testing.T) {
+	input := `"\n\r\t\\\""`
+
+	tests := []struct {
+		expectedType    token.Type
+		expectedLiteral string
+	}{
+		{token.STRING, "\n\r\t\\\""},
+		{token.EOF, ""},
+	}
+	l := New(input)
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+
+}
 func TestSimpleComment(t *testing.T) {
 	input := `=+// This is a comment
 // This is still a comment

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -136,6 +136,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
 	p.registerPrefix(token.LPAREN, p.parseGroupedExpression)
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)
+	p.registerPrefix(token.NULL, p.parseNull)
 	p.registerPrefix(token.REGEXP, p.parseRegexpLiteral)
 	p.registerPrefix(token.REGEXP, p.parseRegexpLiteral)
 	p.registerPrefix(token.STRING, p.parseStringLiteral)
@@ -502,6 +503,11 @@ func (p *Parser) parseSwitchStatement() ast.Expression {
 // parseBoolean parses a boolean token.
 func (p *Parser) parseBoolean() ast.Expression {
 	return &ast.Boolean{Token: p.curToken, Value: p.curTokenIs(token.TRUE)}
+}
+
+// parseNull parses a null keyword
+func (p *Parser) parseNull() ast.Expression {
+	return &ast.NullLiteral{Token: p.curToken}
 }
 
 // parsePrefixExpression parses a prefix-based expression.

--- a/token/token.go
+++ b/token/token.go
@@ -54,6 +54,7 @@ const (
 	MOD             = "%"
 	NOT_CONTAINS    = "!~"
 	NOT_EQ          = "!="
+	NULL            = "null"
 	OR              = "||"
 	PERIOD          = "."
 	PLUS            = "+"
@@ -88,6 +89,7 @@ var keywords = map[string]Type{
 	"if":       IF,
 	"in":       IN,
 	"let":      LET,
+	"null":     NULL,
 	"return":   RETURN,
 	"switch":   SWITCH,
 	"true":     TRUE,


### PR DESCRIPTION
Support the `null` keyword, which allows usage like this:

```
a = [ "foo", null, "OK" ];
let i = 0;
     for( i < len(a) ) {
        puts( "Array index ", i, " contains ", a[i], "\n");
        i++
     }
```

Or

```
 
a = null;
puts( a, null, "\n" );

```