### PR TITLE
Correct the iteration of key/values of hashes

### DIFF
--- a/.github/build
+++ b/.github/build
@@ -3,6 +3,10 @@
 # The basename of our binary
 BASE="monkey"
 
+
+# I don't even ..
+go env -w GOFLAGS="-buildvcs=false"
+
 #
 # We build on multiple platforms/archs
 #

--- a/.github/run-tests.sh
+++ b/.github/run-tests.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # Install the lint-tool, and the shadow-tool
-go get -u golang.org/x/lint/golint
-go get -u golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
+go install golang.org/x/lint/golint@latest
+go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest
 
 # At this point failures cause aborts
 set -e

--- a/.github/run-tests.sh
+++ b/.github/run-tests.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+
+# I don't even ..
+go env -w GOFLAGS="-buildvcs=false"
+
 # Install the lint-tool, and the shadow-tool
 go install golang.org/x/lint/golint@latest
 go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest


### PR DESCRIPTION
This commit adds a test-case which checks that the iteration over hash keys returns the correct results.  It seems that the value varies over runs - so repeating the test ten times is likely sufficient to trigger the issue.

Once this bug is fixed this will close #90.