### PR TITLE
89 examples

### DIFF
--- a/examples/env.mon
+++ b/examples/env.mon
@@ -14,7 +14,7 @@ puts( "Your home is ", os.getenv("HOME"), "\n" );
 
 // Split $PATH into fields, based upon the `:` character
 puts( "Directories on your system PATH\n");
-let paths = string.split( os.getenv("PATH"), ":" );
+let paths = os.getenv("PATH").split(":");
 
 // Loop over the results
 let i = 0;

--- a/examples/sort.mon
+++ b/examples/sort.mon
@@ -6,8 +6,8 @@
 
 
 // Dump the array.
-function dump( in ) {
-  if ( in.sorted?() ) {
+function dump( input ) {
+  if ( input.sorted?() ) {
      puts( "\tThe array is sorted\n");
   } else {
      puts( "\tThe array is not sorted\n");


### PR DESCRIPTION
This pull-request closes #89, by correctly using the type-method to split a string into an array.

Also the example "sort.mon" was updated, as this was giving a syntax error when executed -  `in` is a keyword nowadays, so using this word as a parameter name for a function caused errors and confusion.