### PR TITLE
94 - Ensure bogus regexps are caught

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -699,7 +699,7 @@ if ( name ~= /+/i ) { puts( "Hello\n" ); }
 	ev1 := testEval(literal)
 	er1, ok1 := ev1.(*object.Error)
 	if !ok1 {
-		t.Errorf("Expected an error wit hab ogus regexp, got none")
+		t.Errorf("Expected an error with a bogus regexp, got none")
 	}
 
 	if !strings.Contains(er1.Inspect(), "parsing regexp") {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -688,3 +688,36 @@ return total;
 	}
 
 }
+
+// TestIssue94 tests #94 - that malformed regexps are caught
+func TestIssue94(t *testing.T) {
+	literal := `
+name = "Steve"
+
+if ( name ~= /+/i ) { puts( "Hello\n" ); }
+`
+	ev1 := testEval(literal)
+	er1, ok1 := ev1.(*object.Error)
+	if !ok1 {
+		t.Errorf("Expected an error wit hab ogus regexp, got none")
+	}
+
+	if !strings.Contains(er1.Inspect(), "parsing regexp") {
+		t.Errorf("Got an error, but not the right one:%v", er1.Inspect())
+	}
+
+	match := `
+name = "Steve"
+
+if (match( "+", name) ) { puts( "Hello\n" ); }
+`
+	ev2 := testEval(match)
+	er2, ok2 := ev2.(*object.Error)
+	if !ok2 {
+		t.Errorf("Expected an error with a bogus regexp, got none")
+	}
+	if !strings.Contains(er2.Inspect(), "parsing regexp") {
+		t.Errorf("Got an error, but not the right one:%v", er2.Inspect())
+	}
+
+}

--- a/evaluator/stdlib_core.go
+++ b/evaluator/stdlib_core.go
@@ -171,7 +171,11 @@ func matchFun(args ...object.Object) object.Object {
 	//
 	// Compile and match
 	//
-	reg := regexp.MustCompile(args[0].(*object.String).Value)
+	reg, err := regexp.Compile(args[0].(*object.String).Value)
+	if err != nil {
+		return newError("failed to compile regexp %s: %s",
+			args[0].Inspect(), err)
+	}
 	res := reg.FindStringSubmatch(args[1].(*object.String).Value)
 
 	if len(res) > 0 {


### PR DESCRIPTION
We previously handled malformed regular expressions when using them as literals, but it was noted by @DeadlySurgeon that the `match` function had no such handling.

This pull-request will close #94 by ensuring that bogus regular expressions are caught even in the `match` function.