### PR TITLE
Have Evaluator not discard context after recursion

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -58,9 +58,8 @@ func testEval(input string) object.Object {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5000*time.Millisecond)
 	defer cancel()
-	SetContext(ctx)
 
-	return Eval(program, env)
+	return EvalContext(ctx, program, env)
 }
 
 func testDecimalObject(t *testing.T, obj object.Object, expected interface{}) bool {
@@ -638,15 +637,16 @@ for ( true ) {
   i++;
 }
 `
-	ctx, cancel := context.WithTimeout(context.Background(), 350*time.Millisecond)
-	defer cancel()
 
 	l := lexer.New(input)
 	p := parser.New(l)
 	program := p.ParseProgram()
 	env := object.NewEnvironment()
-	SetContext(ctx)
-	evaluated := Eval(program, env)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 350*time.Millisecond)
+	defer cancel()
+
+	evaluated := EvalContext(ctx, program, env)
 
 	errObj, ok := evaluated.(*object.Error)
 	if !ok {

--- a/evaluator/stdlib_core.go
+++ b/evaluator/stdlib_core.go
@@ -1,6 +1,7 @@
 package evaluator
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -65,7 +66,7 @@ func evalFun(env *object.Environment, args ...object.Object) object.Object {
 		program := p.ParseProgram()
 		if len(p.Errors()) == 0 {
 			// evaluate it, and return the output.
-			return (Eval(program, env))
+			return EvalContext(context.Background(), program, env)
 		}
 
 		// Otherwise abort.  We should have try { } catch


### PR DESCRIPTION
Resolves https://github.com/skx/monkey/issues/93

This PR rewrites functions in `evaluator` to ensure that the context is being passed around correctly and not discarded on recursion. This ensures that any timeout specified in the context, or if a context is canceled, it will have a chance to get through the evaluation. 