### PR TITLE
feat: Add Support for Accessing Index Values Using the Dot Operator

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1008,15 +1008,22 @@ func (p *Parser) parseMethodCallExpression(obj ast.Expression) ast.Expression {
 	if p.peekToken.Type != token.LPAREN {
 		var index ast.Expression
 
-		// If the current token is an identifier, treat it as a string literal index.
-		if p.curToken.Type == token.IDENT {
-			// Create a string literal index token.
+		switch p.curToken.Type {
+		case token.IDENT:
+			// If the current token is an identifier, treat it as a string literal index.
 			indexToken := token.Token{Type: token.STRING, Literal: p.curToken.Literal}
 			index = &ast.StringLiteral{Token: indexToken, Value: indexToken.Literal}
-		} else {
+		case token.INT:
+			// If it's an integer, parse it as an integer literal expression.
+			index = p.parseIntegerLiteral()
+		case token.TRUE, token.FALSE:
+			// If it's a boolean literal, parse it as a boolean expression.
+			index = p.parseBoolean()
+		default:
 			// Otherwise, parse the index expression.
 			index = p.parseExpression(LOWEST)
 		}
+
 		// Return an index expression.
 		return &ast.IndexExpression{Token: currentToken, Left: obj, Index: index}
 	}
@@ -1024,6 +1031,7 @@ func (p *Parser) parseMethodCallExpression(obj ast.Expression) ast.Expression {
 	// Parse the method name as an identifier.
 	name := p.parseIdentifier()
 	p.nextToken()
+
 	// Parse the method call expression and return an object call expression.
 	return &ast.ObjectCallExpression{Token: currentToken, Object: obj, Call: p.parseCallExpression(name)}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -60,7 +60,7 @@ func TestBadLetConstStatement(t *testing.T) {
 	}
 }
 
-//TestConstStatements tests the "const" token.
+// TestConstStatements tests the "const" token.
 func TestConstStatements(t *testing.T) {
 	tests := []struct {
 		input              string
@@ -748,6 +748,46 @@ func TestParsingIndexExpression(t *testing.T) {
 	}
 	if !testInfixExpression(t, indexExp.Index, 1, "+", 1) {
 		return
+	}
+}
+
+func TestParsingIndexExpressionByDot(t *testing.T) {
+	input := `myArray.name;
+	myArray.2`
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+	stmt, _ := program.Statements[0].(*ast.ExpressionStatement)
+	indexExp, ok := stmt.Expression.(*ast.IndexExpression)
+	if !ok {
+		t.Fatalf("exp not *ast.IndexExpression. got=%T", stmt.Expression)
+	}
+	if !testIdentifier(t, indexExp.Left, "myArray") {
+		return
+	}
+	literal, ok := indexExp.Index.(*ast.StringLiteral)
+	if !ok {
+		t.Fatalf("exp not *ast.StringLiteral. got=%T", indexExp.Index)
+	}
+	if literal.Value != "name" {
+		t.Errorf("literal.Value not %q, got=%q", "name", literal.Value)
+	}
+
+	stmt, _ = program.Statements[1].(*ast.ExpressionStatement)
+	indexExp, ok = stmt.Expression.(*ast.IndexExpression)
+	if !ok {
+		t.Fatalf("exp not *ast.IndexExpression. got=%T", stmt.Expression)
+	}
+	if !testIdentifier(t, indexExp.Left, "myArray") {
+		return
+	}
+	bLiteral, ok := indexExp.Index.(*ast.IntegerLiteral)
+	if !ok {
+		t.Fatalf("exp not *ast.IntegerLiteral. got=%T", indexExp.Index)
+	}
+	if bLiteral.Value != 2 {
+		t.Errorf("literal.Value not %q, got=%q", "2", bLiteral.Value)
 	}
 }
 


### PR DESCRIPTION
Enhanced the codebase to enable index value access through the dot operator.

#### Code

```
package main

import (
	"fmt"
	"strings"

	"github.com/skx/monkey/evaluator"
	"github.com/skx/monkey/lexer"
	"github.com/skx/monkey/object"
	"github.com/skx/monkey/parser"
)

func main() {
	condition := `
let a = [{"name":"monkey",
         true:1, false: {"test": "multiTest"},
         7:"seven"}];
puts(a[0].false["test"], "\n")
puts(a.0.false.test, "\n")
puts(a[0].true, "\n")
puts(a.0[true], "\n")
`

	env := object.NewEnvironment()
	p := parser.New(lexer.New(condition))
	expr := p.ParseProgram()
	if len(p.Errors()) != 0 {
		fmt.Printf("failed to parse conditional program: %s", strings.Join(p.Errors(), "; "))
	} else {
		res := evaluator.Eval(expr, env)
		fmt.Println(res)
	}
}

```

#### Output

```
multiTest
multiTest
1
1
&{}
```